### PR TITLE
Updates tiller-namespace flag and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ for that.
 ```
 $ cd $GOPATH/src/github.com/maorfr/helm-backup
 $ make bootstrap build
-$ SKIP_BIN_INSTALL=1 helm plugin install $GOPATH/src/github.com/maorfr/helm-backup
+$ HELM_PUSH_PLUGIN_NO_INSTALL_HOOK=1 helm plugin install $GOPATH/src/github.com/maorfr/helm-backup
 ```
 
 That last command will skip fetching the binary install and use the one you

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	f := cmd.Flags()
-	f.StringVar(&tillerNamespace, "tiller-namespace", "kube-system", "namespace of Tiller")
+	f.StringVarP(&tillerNamespace, "tiller-ns","t", "kube-system", "namespace of Tiller")
 	f.StringVarP(&label, "label", "l", "OWNER=TILLER", "label to select tiller resources by")
 	f.StringVar(&file, "file", "", "file name to use (.tgz file). If not provided - will use <namespace>.tgz")
 	f.BoolVarP(&restore, "restore", "r", false, "restore instead of backup")


### PR DESCRIPTION
Hi @maorfr,
i spent some time digging around why your utility doesn't work when Tiller sits in a namespace other than "kube-system". It became obvious that --tiller-namespace flag can't be set for backup plugin itself because helm already has the same flag and doesn't want to share it with anyone else :). I propose to change the flag name to something like --tiller-ns or use short flag like "-t". 

p.s. btw i changed SKIP_BIN_INSTALL to HELM_PUSH_PLUGIN_NO_INSTALL_HOOK in README.md coz first one doesn't work.