### PR TITLE
Use kubectl create to create the release manifests

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func Restore(namespace string) error {
 	restoreCmd := []string{
 		"kubectl",
 		"--namespace", tillerNamespace,
-		"apply", "-f", manifestsFileName,
+		"create", "-f", manifestsFileName,
 	}
 	releasesToRestore := (string)(releases)
 	log.Printf("releases found to restore: %s", prettyPrint(releasesToRestore))


### PR DESCRIPTION
Fixes #10 
- Not possible to use `replace` as it expects the resource to be available
- Using `create`: this fails if the resource already exist. As we already warn user with 'this command will fail if releases exist', this makes more sense to me